### PR TITLE
Remove declaration of static function XPCServiceConnectionHandler. Th…

### DIFF
--- a/XPCKit/XPCService.h
+++ b/XPCKit/XPCService.h
@@ -37,7 +37,3 @@
 +(void)runService;
 
 @end
-
-// You can supply this as the parameter to xpc_main (but you might as
-// well just call +[XPService runServiceWithConnectionHandler:])
-static void XPCServiceConnectionHandler(xpc_connection_t handler);


### PR DESCRIPTION
…e presence of this declaration caused warnings about unimplemented functions in files that import the header and have -Wunused-functions enabled. I don't see any value to retaining the declaration in the public header, as it's declared static and thus private to the implementation. Steve Streza's original comment that you probably shouldn't explicilty pass the function to xpc_main seems like more than just a good idea.