### PR TITLE
Error Handling

### DIFF
--- a/XPCKit/NSObject+XPCParse.m
+++ b/XPCKit/NSObject+XPCParse.m
@@ -48,9 +48,6 @@
     }else if(type == XPC_TYPE_BOOL || type == XPC_TYPE_UINT64 || type == XPC_TYPE_INT64 || type == XPC_TYPE_DOUBLE){
         object = [NSNumber numberWithXPCObject:xpcObject];
     }
-    else if([[(__bridge NSObject *)type className] isEqualToString: @"OS_xpc_mach_send"]){
-        object = [XPCIOSurface surfaceRefWithXPCObject: xpcObject];
-    }
     else if (xpcObject == XPC_ERROR_CONNECTION_INTERRUPTED ||
              xpcObject == XPC_ERROR_CONNECTION_INVALID ||
              xpcObject == XPC_ERROR_KEY_DESCRIPTION ||

--- a/XPCKit/NSObject+XPCParse.m
+++ b/XPCKit/NSObject+XPCParse.m
@@ -47,7 +47,16 @@
 		object = [NSFileHandle fileHandleWithXPCObject:xpcObject];
     }else if(type == XPC_TYPE_BOOL || type == XPC_TYPE_UINT64 || type == XPC_TYPE_INT64 || type == XPC_TYPE_DOUBLE){
         object = [NSNumber numberWithXPCObject:xpcObject];
-	}
+    }
+    else if([[(__bridge NSObject *)type className] isEqualToString: @"OS_xpc_mach_send"]){
+        object = [XPCIOSurface surfaceRefWithXPCObject: xpcObject];
+    }
+    else if (xpcObject == XPC_ERROR_CONNECTION_INTERRUPTED ||
+             xpcObject == XPC_ERROR_CONNECTION_INVALID ||
+             xpcObject == XPC_ERROR_KEY_DESCRIPTION ||
+             xpcObject == XPC_ERROR_TERMINATION_IMMINENT) {
+        object = [NSDictionary dictionaryWithContentsOfXPCObject: xpcObject];
+    }
     return object;
 }
 


### PR DESCRIPTION
If XPC does return an error, this patch boxes the error into a dictionary so the main app can handle it.